### PR TITLE
readme: add security session in template

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## before turning a private repository to public
 - Check if there is any sensitive data on the code and commit history
-- Add a SECURITY.md using the [template](../template/SECURITY.md). If necessary, make changes to it.
+- Verify if the security `Session` is present in project [readme template(../template/README.md). If necessary, make changes to it.
 - Add security testing (sonarqube, snyk.io, etc..). Make sure there isn't any serious vulnerability pointed by those tests. The Security-team can help you with that.
 
 ## for opensource repositories
@@ -19,6 +19,6 @@ echo 'env' >> .gitignore
 - Remove the info and clear Github history ([force push rewrite history](https://help.github.com/articles/removing-sensitive-data-from-a-repository/))
 - Assess the impact of leaked data.
 
-Based/inspired on 
+Based/inspired on
 1. Snyk Github Security Best Practices (https://res.cloudinary.com/snyk/image/upload/v1535626770/blog/10_GitHub_Security_Best_Practices_cheat_sheet.pdf)
-2. Github Opensource Guide (https://github.com/github/opensource.guide) 
+2. Github Opensource Guide (https://github.com/github/opensource.guide)

--- a/templates/README.md
+++ b/templates/README.md
@@ -66,6 +66,12 @@ Add additional notes about how to deploy this on a live system
 
 We use [SemVer](http://semver.org/) for versioning. For the versions available, see the [tags on this repository](https://github.com/your/project/tags).
 
+## Security Bugs
+
+Pagar.me has a very strict security culture. Therefore, if any of our projects have any vulnerability that can affect our customers, we have an email for safe disclosure. With that in mind, please do not file public issues; go through the process outlined below.
+
+Please send an email to [security@pagar.me](mailto:security@pagar.me) and describe the bug and the best way to reproduce them. We will reply as soon as possible and do our best to fix the bug as fast as possible too. If there is any sensible data on that email, please encript that using our [gpg key](pagar.me/security.pub)
+
 ## Contributing
 Thank you for your interest in contributing!
 

--- a/templates/SECURITY.md
+++ b/templates/SECURITY.md
@@ -1,6 +1,0 @@
-### Security Bugs
-
-Pagar.me has a very strict security culture. Therefore, if any of our projects have any vulnerability that can affect our customers, we have an email for safe disclosure. With that in mind, please do not file public issues; go through the process outlined below.
-
-Please send an email to [security@pagar.me](mailto:security@pagar.me) and describe the bug and the best way to reproduce them. We will reply as soon as possible and do our best to fix the bug as fast as possible too. If there is any sensible data on that email, please encript that using our [gpg key](pagar.me/security.pub) 
-


### PR DESCRIPTION
This PR is a proposal.
It moves `SECURITY.md` content to the session `Securty  bugs` inside `README.md`.